### PR TITLE
Added code to allow saving the cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ jobs:
 
 **target** - Sets the target directory to be used. Defaults to `public`.
 
+**cache** - Sets the cache directory to be used. Defaults to `cache`.
+
 **command** - Sets the command to be used. Defaults to *blank*. When set is normal Hugo commands used, however `hugo` is skipped.
 
 **pandoc_command** - Sets the Pandoc command used. Defaults to `pandoc-default`. See use of [Pandoc with Hugo](https://github.com/klakegg/docker-hugo#using-pandoc) for more information.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   target:
     description: 'Target directory'
     default: 'public'
+  cache:
+    description: 'Cache directory'
+    default: 'cache'
   command:
     description: 'Build command'
     default: ''

--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ docker(['pull', `klakegg/hugo:${label}`]);
 docker(['run', '--rm' , '-i',
   '-v', `${process.env.GITHUB_WORKSPACE}/${core.getInput('source')}:/src`,
   '-v', `${process.env.GITHUB_WORKSPACE}/${core.getInput('target')}:/target`,
+  '-v', `${process.env.GITHUB_WORKSPACE}/${core.getInput('cache')}:/tmp/hugo_cache`,
   '-e', `HUGO_ENV=${core.getInput('env')}`,
   '-e', `HUGO_PANDOC=${core.getInput('pandoc_command')}`,
   `klakegg/hugo:${label}`]


### PR DESCRIPTION
I wanted to utilize the cache action but this action didn't expose the cache directory, so I updated it to mount the cache directory. 

It can be further enhanced by any users if they use something like the following in their config.toml to store the generated images and assets in the cache directory as well. The other option would be to also expose the generated directory as part of this action.
```
[caches]
  [caches.assets]
    dir = ':cacheDir/:project/_gen'
    maxAge = -1
  [caches.getcsv]
    dir = ':cacheDir/:project'
    maxAge = -1
  [caches.getjson]
    dir = ':cacheDir/:project'
    maxAge = -1
  [caches.images]
    dir = ':cacheDir/:project/_gen'
    maxAge = -1
  [caches.modules]
    dir = ':cacheDir/modules'
    maxAge = -1
```